### PR TITLE
Check stencel paint color and count implementation

### DIFF
--- a/src/components/tabs/StencilCatalogTab.tsx
+++ b/src/components/tabs/StencilCatalogTab.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -54,6 +54,26 @@ export const StencilCatalogTab = () => {
     curbStops: { quantity: 0, pricePer: 0, color: 'unpainted' },
     fireLane: { quantity: 0, pricePer: 0, color: 'red' }
   });
+
+  // Load cart from localStorage on mount
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem('stencilCart');
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        if (Array.isArray(parsed)) {
+          setCart(parsed);
+        }
+      }
+    } catch {}
+  }, []);
+
+  // Persist cart to localStorage whenever it changes
+  useEffect(() => {
+    try {
+      localStorage.setItem('stencilCart', JSON.stringify(cart));
+    } catch {}
+  }, [cart]);
 
   const handleSearch = (term: string) => {
     setSearchTerm(term);
@@ -796,10 +816,19 @@ export const StencilCatalogTab = () => {
       {(cart.length > 0 || getLineStripingTotal() > 0) && (
         <Card className="card-professional border-primary/20">
           <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <ShoppingCart className="h-5 w-5" />
-              Quote Summary
-            </CardTitle>
+            <div className="flex items-center justify-between">
+              <CardTitle className="flex items-center gap-2">
+                <ShoppingCart className="h-5 w-5" />
+                Quote Summary
+              </CardTitle>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setCart([])}
+              >
+                Clear Cart
+              </Button>
+            </div>
           </CardHeader>
           <CardContent>
             <div className="space-y-3">
@@ -809,6 +838,19 @@ export const StencilCatalogTab = () => {
                     <p className="font-medium">{item.stencil.name}</p>
                     <div className="flex items-center gap-2 text-sm text-muted-foreground mt-1">
                       <span>${item.stencil.price} x</span>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setCart(prev => {
+                          const nextQty = item.quantity - 1;
+                          if (nextQty <= 0) {
+                            return prev.filter((_, i) => i !== index);
+                          }
+                          return prev.map((cartItem, i) => i === index ? { ...cartItem, quantity: nextQty } : cartItem);
+                        })}
+                      >
+                        -
+                      </Button>
                       <Input
                         type="number"
                         min={0}
@@ -824,6 +866,13 @@ export const StencilCatalogTab = () => {
                           });
                         }}
                       />
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setCart(prev => prev.map((cartItem, i) => i === index ? { ...cartItem, quantity: item.quantity + 1 } : cartItem))}
+                      >
+                        +
+                      </Button>
                       <Button
                         variant="ghost"
                         size="sm"


### PR DESCRIPTION
Add editable cart quantities and removal, and disable the Fire Lane color dropdown to improve cart management and UX.

The Fire Lane color dropdown was always fixed to red, so disabling it prevents user confusion. The cart previously lacked direct quantity editing and removal, which are now added for better user control.

---
<a href="https://cursor.com/background-agent?bcId=bc-b8f8b77a-472a-47bd-9162-ece43e4a5232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b8f8b77a-472a-47bd-9162-ece43e4a5232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

