### PR TITLE
Build production web and android app

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -7,12 +7,7 @@ android {
   }
 }
 
-def cordovaVars = file("../capacitor-cordova-android-plugins/cordova.variables.gradle")
-if (cordovaVars.exists()) {
-  apply from: cordovaVars
-} else {
-  logger.lifecycle("cordova.variables.gradle not found, skipping Cordova apply")
-}
+apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
     implementation project(':capacitor-community-background-geolocation')
 


### PR DESCRIPTION
Unconditionally apply `cordova.variables.gradle` to ensure proper configuration for Android production builds.

The previous conditional check for `cordova.variables.gradle` could lead to build issues if the file was not found or if its application was unexpectedly skipped, preventing necessary variables from being set for the Capacitor Android project. Removing the conditional ensures these variables are always applied, which is crucial for a robust production build pipeline.

---
<a href="https://cursor.com/background-agent?bcId=bc-0e0f4668-1573-42a5-b977-f8ba5c6f8b08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0e0f4668-1573-42a5-b977-f8ba5c6f8b08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

