### PR TITLE
Check ai map availability in overwatch tab

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { supabase } from "@/integrations/supabase/client";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
 import Overwatch from "./pages/Overwatch";
+import AiMap from "./pages/AiMap";
 
 const queryClient = new QueryClient();
 
@@ -188,11 +189,13 @@ const App = () => {
             <div className="max-w-6xl mx-auto px-4 py-2 flex items-center gap-4 text-sm">
               <Link to="/" className="hover:underline">Home</Link>
               <Link to="/overwatch" className="hover:underline">Overwatch</Link>
+              <Link to="/ai-map" className="hover:underline">AI Map</Link>
             </div>
           </div>
           <Routes>
             <Route path="/" element={<Index />} />
             <Route path="/overwatch" element={<Overwatch />} />
+            <Route path="/ai-map" element={<AiMap />} />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/src/pages/AiMap.tsx
+++ b/src/pages/AiMap.tsx
@@ -1,0 +1,8 @@
+import AsphaltMap from "@/components/AsphaltMap";
+
+const AiMap = () => {
+  return <AsphaltMap />;
+};
+
+export default AiMap;
+


### PR DESCRIPTION
Add a dedicated 'AI Map' navigation tab and page to provide direct access to the AsphaltMap component.

---
<a href="https://cursor.com/background-agent?bcId=bc-5a398211-cede-464c-94f3-de53eda03a2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5a398211-cede-464c-94f3-de53eda03a2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

